### PR TITLE
chore: update sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -21,4 +21,7 @@ jobs:
         uses: BetaHuhn/repo-file-sync-action@v1
         with:
           GH_INSTALLATION_TOKEN: ${{ steps.generate_token.outputs.token }}
+          COMMIT_PREFIX: 'chore:'
+          ORIGINAL_MESSAGE: true
+          COMMIT_AS_PR_TITLE: true
           SKIP_PR: true


### PR DESCRIPTION
* Change commit prefix to abide by our contribution guidelines.
* Use the original commit's message if only a single commit is being synced.
* Use the original commit as the PR title if available.