### PR TITLE
chore: don't use original message and remove unused pr title option

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -22,6 +22,4 @@ jobs:
         with:
           GH_INSTALLATION_TOKEN: ${{ steps.generate_token.outputs.token }}
           COMMIT_PREFIX: 'chore:'
-          ORIGINAL_MESSAGE: true
-          COMMIT_AS_PR_TITLE: true
           SKIP_PR: true


### PR DESCRIPTION
Reverts 2 options added in #4:
- Remove `ORIGINAL_MESSAGE` to avoid weird commit messages with invalid PR links such as Qbox-project/qbx_core@c1323a6.
- Remove `COMMIT_AS_PR_TITLE` since we skip PRs anyway.