### PR TITLE
chore(workflows/lint): use `qbox_lib` instead of `qbox_utils`

### DIFF
--- a/repo-template/.github/workflows/lint.yml
+++ b/repo-template/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           capture: "junit.xml"
           args: "-t --formatter JUnit"
-          extra_libs: ox_lib+mysql+qblocales+qbox+qbox_playerdata+qbox_utils+qbox_utils_sv+qbox_utils_cl
+          extra_libs: ox_lib+mysql+qblocales+qbox+qbox_playerdata+qbox_lib
       - name: Generate Lint Report
         if: always()
         uses: mikepenz/action-junit-report@v3


### PR DESCRIPTION
Use linting for the new lib module.