### PR TITLE
chore(template/workflows): bump dependency & nodejs versions

### DIFF
--- a/repo-template/.github/workflows/discord-commit.yml
+++ b/repo-template/.github/workflows/discord-commit.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4
     - name: Discord Webhook
       uses: ChatDisabled/discord-commits@main
       with:

--- a/repo-template/.github/workflows/discord-release.yml
+++ b/repo-template/.github/workflows/discord-release.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4
     - name: Github Releases To Discord
-      uses: SethCohen/github-releases-to-discord@v1.13.1
+      uses: SethCohen/github-releases-to-discord@v1
       with:
         webhook_url: ${{ secrets.WEBHOOK_URL }}
         color: "15852866"

--- a/repo-template/.github/workflows/issues-project.yml
+++ b/repo-template/.github/workflows/issues-project.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get App Token
-        uses: actions/create-github-app-token@v1.6.1
+        uses: actions/create-github-app-token@v1
         id: generate_token
         with:
           app-id: ${{ secrets.APP_ID }}

--- a/repo-template/.github/workflows/lint.yml
+++ b/repo-template/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ jobs:
     name: Lint Resource
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Lint
@@ -16,7 +16,7 @@ jobs:
           extra_libs: ox_lib+mysql+qblocales+qbox+qbox_playerdata+qbox_lib
       - name: Generate Lint Report
         if: always()
-        uses: mikepenz/action-junit-report@v3
+        uses: mikepenz/action-junit-report@v4
         with:
           report_paths: "**/junit.xml"
           check_name: Linting Report

--- a/repo-template/.github/workflows/release-action.yml
+++ b/repo-template/.github/workflows/release-action.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: "ubuntu-latest"
         steps:
             - name: Checkout Repository
-              uses: actions/checkout@v4.1.1
+              uses: actions/checkout@v4
               with:
                 fetch-depth: 0
                 ref: ${{ github.event.repository.default_branch }}
@@ -28,14 +28,14 @@ jobs:
                 zip -r ./${{ github.event.repository.name }}.zip ./${{ github.event.repository.name }}
 
             - name: Get App Token
-              uses: actions/create-github-app-token@v1.6.1
+              uses: actions/create-github-app-token@v1
               id: generate_token
               with:
                 app-id: ${{ secrets.APP_ID }}
                 private-key: ${{ secrets.PRIVATE_KEY }}
 
             - name: Create Release
-              uses: 'marvinpinto/action-automatic-releases@latest'
+              uses: marvinpinto/action-automatic-releases@latest
               with:
                 title: ${{ github.ref_name }}
                 repo_token: '${{ steps.generate_token.outputs.token }}'

--- a/repo-template/.github/workflows/release.yml
+++ b/repo-template/.github/workflows/release.yml
@@ -12,21 +12,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Get App Token
-        uses: actions/create-github-app-token@v1.6.1
+        uses: actions/create-github-app-token@v1
         id: generate_token
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Checkout Repository
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
         with:
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Bump manifest version
         run: node .github/actions/bump-manifest-version.js
@@ -34,7 +34,7 @@ jobs:
           TGT_RELEASE_VERSION: ${{ inputs.version }}
 
       - name: Push manifest change
-        uses: EndBug/add-and-commit@latest
+        uses: EndBug/add-and-commit@v9
         with:
           add: fxmanifest.lua
           push: true


### PR DESCRIPTION
- Some actions that we use are outdated, so bump them and/or only explicitly set their major version to avoid manually bumping unless a new major version releases (excluding v0 actions).
- Node.js v16 is [deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20) so update it to LTS v20 in the `release.yml` action.

AFAIK the only changes done in the actions where I bumped the major version are updating from Node.js v12 to v16, or v16 to v20 which shouldn't have an effect on our repos.