### PR TITLE
fix(template/workflows): revert to explicit version for release action

### DIFF
--- a/repo-template/.github/workflows/discord-release.yml
+++ b/repo-template/.github/workflows/discord-release.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Github Releases To Discord
-      uses: SethCohen/github-releases-to-discord@v1
+      uses: SethCohen/github-releases-to-discord@v1.15.0
       with:
         webhook_url: ${{ secrets.WEBHOOK_URL }}
         color: "15852866"


### PR DESCRIPTION
This action doesn't provide a `v1` tag.