### PR TITLE
chore(discord-release): update release to discord action

### DIFF
--- a/repo-template/.github/workflows/discord-release.yml
+++ b/repo-template/.github/workflows/discord-release.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Github Releases To Discord
-      uses: SethCohen/github-releases-to-discord@v1.15.0
+      uses: SethCohen/github-releases-to-discord@v1.15.1
       with:
         webhook_url: ${{ secrets.WEBHOOK_URL }}
         color: "15852866"


### PR DESCRIPTION
The [`SethCohen/github-releases-to-discord`](https://github.com/SethCohen/github-releases-to-discord/releases/tag/v1.15.1) action was recently updated with a rewrite. The version we use has an issue with commit links, and this update should fix it.

Example; see the hyperlink not working:
![image](https://github.com/user-attachments/assets/23387de2-b5e4-4b23-9ae6-3ee5aafaf5fa)
