### PR TITLE
chore(discord-release): update release to discord action

### DIFF
--- a/repo-template/.github/workflows/discord-release.yml
+++ b/repo-template/.github/workflows/discord-release.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
     - name: Github Releases To Discord
-      uses: SethCohen/github-releases-to-discord@v1.15.1
+      uses: SethCohen/github-releases-to-discord@v1.16.2
       with:
         webhook_url: ${{ secrets.WEBHOOK_URL }}
         color: "15852866"


### PR DESCRIPTION
Our releases still have some messed up links, and the GitHub action for those was updated with supposed bug fixes for this.