### PR TITLE
fix(release-action): allow release to create without changelog

### DIFF
--- a/repo-template/.github/workflows/release-action.yml
+++ b/repo-template/.github/workflows/release-action.yml
@@ -37,6 +37,7 @@ jobs:
             - name: Update CHANGELOG
               id: changelog
               uses: requarks/changelog-action@v1
+              continue-on-error: true
               with:
                 token: ${{ steps.generate_token.outputs.token }}
                 tag: ${{ github.ref_name }}


### PR DESCRIPTION
In the event that a previous tag does not exist this will allow the release action to continue and not fail.